### PR TITLE
send-webmentions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,32 @@
 import { syndicate } from './lib/syndicate/index.js'
 import { validateWebhook } from './lib/validateWebhook.js'
+import { send as sendWebmentions } from './lib/webmentions/index.js'
 
 export const webhooks = async (req, res) => {
   const authorizedWebhook = validateWebhook(req)
-
-  if (!authorizedWebhook) {
-    res.status(401).send('Unauthorized')
-    return
-  }
 
   if (req.method !== 'POST') {
     res.status(405).send('Method not allowed')
     return
   }
 
+  if (!authorizedWebhook) {
+    res.status(401).send('Unauthorized')
+    return
+  }
+
   const { path } = req
-  const { post } = req.body
+  // Ghost sends pretty much the same data for all webhooks,
+  // but the top-level key changes depending on the content type
+  const payload = Object.values(req.body)[0]
 
   try {
     switch (path) {
       case '/syndicate':
-        await syndicate(post)
+        await syndicate(payload)
+        break
+      case '/send-webmentions':
+        await sendWebmentions(payload)
         break
     }
   } catch (error) {

--- a/src/lib/webmentions/index.js
+++ b/src/lib/webmentions/index.js
@@ -1,0 +1,34 @@
+export function send(post) {
+  const WEBMENTIONS_ENDPOINT = 'https://webmention.app/check'
+
+  if (!post?.current?.url) {
+    return Promise.resolve('No URL to send webmentions to')
+  }
+
+  const query = new URLSearchParams({
+    url: post.current.url,
+    token: process.env.WEBMENTION_APP_TOKEN,
+  }).toString()
+
+  return fetch(`${WEBMENTIONS_ENDPOINT}?${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then(async response => {
+    if (!response.ok) {
+      return Promise.reject(`Failed to send webmentions: ${response.status}`)
+    }
+
+    const { urls: sentMentions } = await response.json()
+    const message = `Sent ${sentMentions.length} webmentions for ${post.current.url}`
+
+    console.log(message)
+
+    sentMentions.forEach(({ target, status }) => {
+      console.log(`${status}: ${target}`)
+    })
+
+    return message
+  })
+}

--- a/src/lib/webmentions/index.test.js
+++ b/src/lib/webmentions/index.test.js
@@ -1,0 +1,52 @@
+import { send } from './index'
+
+describe('send', () => {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => null)
+  const originalFetch = global.fetch
+  const WEBMENTIONS_ENDPOINT = 'https://webmention.app/check'
+
+  beforeEach(() => {
+    global.fetch = vi.fn()
+    process.env.WEBMENTION_APP_TOKEN = 'test-token'
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('should resolve with a message if no URL is provided', async () => {
+    const post = { current: {} }
+    const result = await send(post)
+    expect(result).toBe('No URL to send webmentions to')
+  })
+
+  it('should send webmentions and log the results', async () => {
+    const post = { current: { url: 'https://example.com' } }
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        urls: [{ target: 'https://target.com', status: 'success' }],
+      }),
+    }
+    global.fetch.mockResolvedValue(mockResponse)
+
+    const result = await send(post)
+    expect(result).toBe('Sent 1 webmentions for https://example.com')
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${WEBMENTIONS_ENDPOINT}?url=https%3A%2F%2Fexample.com&token=test-token`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    expect(log).toHaveBeenCalledWith('success: https://target.com')
+  })
+
+  it('should reject with an error message if the fetch fails', async () => {
+    const post = { current: { url: 'https://example.com' } }
+    const mockResponse = { ok: false, status: 500 }
+    global.fetch.mockResolvedValue(mockResponse)
+
+    await expect(send(post)).rejects.toBe('Failed to send webmentions: 500')
+  })
+})


### PR DESCRIPTION
A very thin wrapper around http calls to [webmention.app](https://webmention.app) to send webmentions when content is published